### PR TITLE
fix(types): sync RuntimeEvent with canonical RuntimeEventType

### DIFF
--- a/examples/code-pipeline/index.ts
+++ b/examples/code-pipeline/index.ts
@@ -222,10 +222,10 @@ async function main() {
 
   // Wire up observability
   for (const [name, rt] of [['shaper', shaperRuntime], ['critic', criticRuntime], ['keeper', keeperRuntime]] as const) {
-    rt.on('signal:processed', (signal: Signal) => {
+    rt.on('action:completed', (signal: Signal) => {
       // Just for demo visibility
     });
-    rt.on('signal:claim-conflict', (signal: Signal) => {
+    rt.on('signal:claim_failed', (signal: Signal) => {
       console.log(`   ⚡ Claim conflict in ${name}: ${signal.type}`);
     });
   }

--- a/src/core/runtime.ts
+++ b/src/core/runtime.ts
@@ -193,7 +193,7 @@ export class ColonyRuntime implements IColonyRuntime {
         }
       } catch (err) {
         this._stats.errors++;
-        this.emit('colony:error', err);
+        this.emit('action:failed', err);
         this.log('error', `Sensor poll error: ${err}`);
       }
     };
@@ -282,7 +282,7 @@ export class ColonyRuntime implements IColonyRuntime {
             signalId: signal.id,
             signalType: signal.type,
           });
-          this.emit('signal:claim-conflict', signal, colonyName);
+          this.emit('signal:claim_failed', signal, colonyName);
           this.log('debug', `Claim conflict on ${signal.id} — another colony got it`);
           this.processingSignals.delete(signal.id);
           this._activeCount--;
@@ -324,7 +324,7 @@ export class ColonyRuntime implements IColonyRuntime {
         rule: rule.name,
         duration: actionDuration,
       });
-      this.emit('signal:processed', signal, colonyName);
+      this.emit('action:completed', signal, colonyName);
 
       // 5. Auto-withdraw if configured
       if (this.definition.config?.autoWithdraw) {
@@ -350,7 +350,7 @@ export class ColonyRuntime implements IColonyRuntime {
         duration: actionDuration,
         error: err instanceof Error ? err.message : String(err),
       });
-      this.emit('colony:error', err, signal);
+      this.emit('action:failed', err, signal);
       this.log('error', `Error processing signal ${signal.id}: ${err}`);
 
       // Release claim on error so another agent can pick it up

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -327,15 +327,12 @@ export interface RuntimeStats {
   avgProcessingMs: number;
 }
 
-export type RuntimeEvent =
-  | 'signal:sensed'
-  | 'signal:claimed'
-  | 'signal:processed'
-  | 'signal:deposited'
-  | 'signal:claim-conflict'
-  | 'colony:started'
-  | 'colony:stopped'
-  | 'colony:error';
+/**
+ * Runtime event types — the canonical set of events emitted by the stigmergy loop.
+ * Re-exported from events.ts as RuntimeEvent for backward compatibility.
+ */
+import type { RuntimeEventType } from './events.js';
+export type RuntimeEvent = RuntimeEventType;
 
 // ----------------------------------------------------------
 // Decay — pheromone evaporation

--- a/tests/core/runtime.test.ts
+++ b/tests/core/runtime.test.ts
@@ -610,12 +610,12 @@ describe('runtime — legacy on() events', () => {
     expect(events).toEqual(['started', 'stopped']);
   });
 
-  it('fires signal:processed after action completes', async () => {
+  it('fires action:completed after action completes', async () => {
     const def = buildColony(async () => {});
     const rt = createRuntime(def);
 
     let processedSignal: Signal | undefined;
-    rt.on('signal:processed', (signal: Signal) => {
+    rt.on('action:completed', (signal: Signal) => {
       processedSignal = signal;
     });
 


### PR DESCRIPTION
## Summary

- Replace stale `RuntimeEvent` type (8 events) in `types.ts` with a re-export of `RuntimeEventType` (14 events) from `events.ts`
- Update legacy `emit()` calls in runtime.ts to use canonical event names
- Update example and test references to match

## Changes

| Old Event Name | New Canonical Name |
|---|---|
| `signal:processed` | `action:completed` |
| `signal:claim-conflict` | `signal:claim_failed` |
| `colony:error` | `action:failed` |

## Test plan

- [x] `npx tsc --noEmit` — zero type errors
- [x] `npx vitest run` — 319/319 tests pass
- [x] Legacy `on()` interface still works with all event types
- [x] Example code updated to use new names

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)