### PR TITLE
feat(providers): add Z.ai/GLM-5 model resolution via zhipu-ai-provider

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "@anthropic-ai/sdk": ">=0.30.0",
     "ai": ">=3.0.0",
     "openai": ">=4.0.0",
+    "zhipu-ai-provider": ">=0.1.0",
     "zod": ">=3.0.0",
     "mysql2": ">=3.0.0"
   },
@@ -118,6 +119,9 @@
       "optional": true
     },
     "@ai-sdk/google": {
+      "optional": true
+    },
+    "zhipu-ai-provider": {
       "optional": true
     },
     "zod": {

--- a/src/providers/llm.ts
+++ b/src/providers/llm.ts
@@ -287,6 +287,16 @@ async function resolveVercelModel(model: string): Promise<any> {
     return google(model.replace('google/', ''));
   }
 
+  if (model.startsWith('glm') || model.startsWith('zai/')) {
+    // @ts-expect-error — optional peer dependency, may not be installed
+    const { createZhipu } = await import('zhipu-ai-provider');
+    const zai = createZhipu({
+      baseURL: process.env.ZAI_BASE_URL ?? 'https://api.z.ai/api/paas/v4',
+      apiKey: process.env.ZAI_API_KEY,
+    });
+    return zai(model.replace('zai/', ''));
+  }
+
   // Default to Anthropic
   const { anthropic } = await import('@ai-sdk/anthropic');
   return anthropic(model);

--- a/src/providers/structured-output.ts
+++ b/src/providers/structured-output.ts
@@ -346,6 +346,16 @@ async function resolveVercelModel(model: string): Promise<any> {
     return google(model.replace('google/', ''));
   }
 
+  if (model.startsWith('glm') || model.startsWith('zai/')) {
+    // @ts-expect-error — optional peer dependency, may not be installed
+    const { createZhipu } = await import('zhipu-ai-provider');
+    const zai = createZhipu({
+      baseURL: process.env.ZAI_BASE_URL ?? 'https://api.z.ai/api/paas/v4',
+      apiKey: process.env.ZAI_API_KEY,
+    });
+    return zai(model.replace('zai/', ''));
+  }
+
   // Default to Anthropic
   const { anthropic } = await import('@ai-sdk/anthropic');
   return anthropic(model);

--- a/tests/providers/llm.test.ts
+++ b/tests/providers/llm.test.ts
@@ -111,6 +111,12 @@ vi.mock('@ai-sdk/google', () => ({
   google: vi.fn().mockReturnValue('mock-google-model'),
 }));
 
+vi.mock('zhipu-ai-provider', () => ({
+  createZhipu: vi.fn().mockReturnValue(
+    vi.fn().mockReturnValue('mock-zai-model')
+  ),
+}));
+
 // ── Tests ───────────────────────────────────────────────────
 
 describe('withLLM', () => {
@@ -432,6 +438,45 @@ describe('withLLM', () => {
         })
       );
       expect(ctx.deposits[0].payload).toEqual({ text: 'Vercel AI generated text' });
+    });
+
+    it('resolves zai/ model prefix via openai-compatible provider', async () => {
+      const handler = withLLM({
+        model: 'zai/glm-5',
+        provider: 'vercel-ai',
+        prompt: 'Test prompt',
+        route: 'output:ready',
+      });
+
+      const ctx = makeContext();
+      await handler(makeSignal(), ctx);
+
+      const { createZhipu } = await import('zhipu-ai-provider');
+      expect(createZhipu).toHaveBeenCalledWith(
+        expect.objectContaining({
+          baseURL: 'https://api.z.ai/api/paas/v4',
+        })
+      );
+      expect(ctx.deposits[0].payload).toEqual({ text: 'Vercel AI generated text' });
+    });
+
+    it('resolves glm model prefix via zhipu-ai-provider', async () => {
+      const handler = withLLM({
+        model: 'glm-5',
+        provider: 'vercel-ai',
+        prompt: 'Test prompt',
+        route: 'output:ready',
+      });
+
+      const ctx = makeContext();
+      await handler(makeSignal(), ctx);
+
+      const { createZhipu } = await import('zhipu-ai-provider');
+      expect(createZhipu).toHaveBeenCalledWith(
+        expect.objectContaining({
+          baseURL: 'https://api.z.ai/api/paas/v4',
+        })
+      );
     });
 
     it('defaults to anthropic when no provider specified', async () => {


### PR DESCRIPTION
## Summary

Adds Z.ai (GLM-5) support to the Vercel AI SDK provider path in `withLLM` and `withStructuredOutput`.

## Changes

- **`src/providers/llm.ts`** / **`src/providers/structured-output.ts`**: Extend `resolveVercelModel()` to detect `glm*` and `zai/` model prefixes and route them through the [`zhipu-ai-provider`](https://github.com/Xiang-CH/zhipu-ai-provider) community package.
- **`package.json`**: Add `zhipu-ai-provider` as an optional peer dependency.
- **`tests/providers/llm.test.ts`**: Add tests for both `zai/glm-5` and `glm-5` prefix resolution.

## Usage

```ts
withLLM({
  provider: 'vercel-ai',
  model: 'zai/glm-5',       // or just 'glm-5'
  prompt: (signal) => `...`,
  route: 'result:ready',
})
```

Set `ZAI_API_KEY` in the environment. Defaults to the Z.ai international endpoint (`https://api.z.ai/api/paas/v4`), overridable via `ZAI_BASE_URL`.

## Other GLM-5 integration paths (no changes needed)

- **Agentic coding via Claude Code**: `withClaudeCode({ apiBaseUrl: 'https://api.z.ai/api/anthropic', model: 'glm-5' })`
- **Agentic coding via OpenCode**: `withOpenCode({ model: 'zai/glm-5' })`

## Tests

All 882 tests pass.